### PR TITLE
ci: add publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,9 @@ name: Publish Workflow
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - 'debug/*'
 
 jobs:
   build:
@@ -14,7 +17,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: '20'
 
     - name: Install pnpm
       run: npm install -g pnpm
@@ -23,12 +26,13 @@ jobs:
       run: pnpm install
 
     - name: Run build script
-      run: pnpm run build
+      run: sh ./.vscode/build.sh
+      # run: pnpm run build
 
     - name: Upload Release Assets
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
-        name: my-artifact-${{ matrix.runs-on }}
+        name: Artifact-${{ matrix.runs-on }}
         path: ./out
 
   release:
@@ -40,26 +44,18 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
-        name: release-assets
+        pattern: Artifact-*
         path: ./out
+        merge-multiple: true
 
-    - name: Create GitHub Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v2
       with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false
-
-    - name: Upload Release Assets
-      uses: actions/upload-release-asset@v1
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./out
-        asset_name: release-assets
-        asset_content_type: application/zip
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        overwrite: true
+        release_name: Release-${{ github.event.head_commit.timestamp | date('YYYY-MM-DD') }}
+        file: ./out/decky-rifm.zip
+        asset_name: decky-rifm.zip
+        tag: ${{ github.event.head_commit.timestamp | date('YYYY-MM-DD') }}

--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 
 # Decky Plugin - ReadItForMe 
 
-This is a personal use decky plugin to read the text of your latest screenshot.
+A personal Decky plugin to read the text from your latest screenshot.
 
 ## Screenshots
 
 (TODO)
 
-## Development ENV Setup
+## Development Environment Setup
 
-1. Set up SSH to login without a password (using RSA).
-2. Run `pnpm i` to install dependencies.
-3. Run `/script/setup.sh` to build, zip, and ship the plugin to Decky.
-4. Install the plugin in Decky-Loader in Dev mode.
-5. Once you see `decky-rifm` in `/homebrew/plugins` in Decky-Loader, you can start developing the plugin.
-6. Change the permissions of that folder: `sudo chmod -R 777 /decky-rifm` to allow overwriting files in that folder.
-7. Make changes in the code, both frontend and backend.
-8. Run `/script/build.sh` again to see the changes in Decky-Loader (you may need to reload or click the reinstall button in Decky-Loader).
+1. Set up SSH for passwordless login (using RSA).
+2. Run `pnpm install` to install dependencies.
+3. Make your code changes.
+4. Run `task:build` to build the project and `task:copyzip` to transfer the zip file to your Deck.
+5. Run `script/deploy.sh` on your Deck to install the plugin.
 
+## TODO
+
+- [x] Add a folder selector to choose where screenshots are saved
+- [ ] Support Chinese language
+- [ ] Publish to the Decky Store


### PR DESCRIPTION
This pull request includes updates to the publish workflow and improvements to the `README.md` file. The most important changes are grouped by theme below.

### Workflow Improvements:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R5-R7): Added push event trigger for branches matching 'debug/*'.
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L17-R20): Updated Node.js version from 14 to 20.
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L26-R35): Changed build script execution to use `sh ./.vscode/build.sh` instead of `pnpm run build`.
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L26-R35): Updated action versions for `upload-artifact` and `download-artifact` to v4 and added `merge-multiple` option. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L26-R35) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L43-R61)
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L43-R61): Replaced `create-release` and `upload-release-asset` actions with `upload-release-action` for uploading binaries to the release.

### Documentation Enhancements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R22): Improved the description and instructions for setting up the development environment and deploying the plugin.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R22): Added a TODO section with tasks for future improvements.